### PR TITLE
add failure keywords to db dump monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Define `docker_database_backup_ping: ""` to activate
 
 The ping on finish includes the exit codes of all dumps so that healthchecks.io will register a fail [as per their docs](https://healthchecks.io/docs/http_api/#exitcode-uuid)  
 That way you will be alerted if any script doesn't finish or finishes with a failed dump.  
+Additionaly you can check the output for any warnings you want to fail on via `docker_database_backup_failure_keywords`
+
 Shot me an issue if an implementation for other services is wanted  
 
 ## Example Playbook
@@ -118,6 +120,7 @@ Shot me an issue if an implementation for other services is wanted
     docker_database_backup_maria_exclude: "testservice"
     docker_database_backup_keep_days: "3"
     docker_database_backup_maria_custom_options: "--max-allowed-packet=1073741824"
+    docker_database_backup_failure_keywords: "collation|unsafe"
   roles:
     - role: fw_oss.docker
       become: true

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Shot me an issue if an implementation for other services is wanted
     docker_database_backup_maria_exclude: "testservice"
     docker_database_backup_keep_days: "3"
     docker_database_backup_maria_custom_options: "--max-allowed-packet=1073741824"
-    docker_database_backup_failure_keywords: "collation|unsafe"
+    docker_database_backup_failure_keywords: "collation|insecure"
   roles:
     - role: fw_oss.docker
       become: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,6 +32,7 @@ docker_database_backup_cron_file: "docker_database_backup"
 docker_database_backup_cron_minute: "{{ 59 | random(seed=inventory_hostname) }}"
 docker_database_backup_cron_hour: "12,21"
 docker_database_backup_ping: ""
+docker_database_backup_failure_keywords: ""
 
 docker_database_backup_mysql_include: "(mariadb|mysql)"  # mariadb < 10.5 uses mysqldump
 docker_database_backup_mysql_exclude: "(^zabbix|mariadb:1[1-9])"

--- a/templates/database_docker_backup.sh.j2
+++ b/templates/database_docker_backup.sh.j2
@@ -69,7 +69,7 @@ do
   BACKUP_FOLDER=${CURRENT_DIR}/backups/$i
   mkdir -p "${BACKUP_FOLDER}"
   docker exec "$i" sh -c 'mariadb-dump --all-databases --single-transaction {{ docker_database_backup_maria_custom_options
-    }} -uroot -p"${MARIADB_ROOT_PASSWORD}"'\
+    }} -uroot -p"${MARIADB_ROOT_PASSWORD}${MYSQL_ROOT_PASSWORD}"'\
     | zstd > "${BACKUP_FOLDER}/$(date +%Y%m%d-%H%M).sql.zst"
 {% if docker_database_backup_ping | length > 0 %}
   SUM_OF_EXIT_CODES+=${PIPESTATUS[0]}

--- a/templates/database_docker_backup.sh.j2
+++ b/templates/database_docker_backup.sh.j2
@@ -131,7 +131,7 @@ done
 grep -E "${LOG_FAILURE_REGEX}" "${CURRENT_DIR}/last_run.txt" && SUM_OF_EXIT_CODES+=1
 {% endif %}
 # prepare message body
-ping_body="${SUM_OF_BACKUPS} backups started:"$'\n'$(tail --bytes=1000 "${CURRENT_DIR}/last_run.txt")
+ping_body="${SUM_OF_BACKUPS} backups started:"$'\n'$(tail --bytes=970 "${CURRENT_DIR}/last_run.txt")
 # call monitoring
 curl -fsS -m 10 --retry 5 -o /dev/null --data-raw "${ping_body}" \
   "{{ docker_database_backup_ping }}/${SUM_OF_EXIT_CODES}"

--- a/templates/database_docker_backup.sh.j2
+++ b/templates/database_docker_backup.sh.j2
@@ -127,8 +127,8 @@ done
 {% if docker_database_backup_ping | length > 0 %}
 # ping monitoring
 {% if docker_database_backup_failure_keywords | length > 0 %}
-# check output for e.g. collation warnings
-cat "${CURRENT_DIR}/last_run.txt" | grep -E "${LOG_FAILURE_REGEX}" || SUM_OF_EXIT_CODES+=1
+# check output for e.g. collation warnings and add to failure count
+grep -E "${LOG_FAILURE_REGEX}" "${CURRENT_DIR}/last_run.txt" && SUM_OF_EXIT_CODES+=1
 {% endif %}
 # prepare message body
 ping_body="${SUM_OF_BACKUPS} backups started:"$'\n'$(tail --bytes=1000 "${CURRENT_DIR}/last_run.txt")

--- a/templates/database_docker_backup.sh.j2
+++ b/templates/database_docker_backup.sh.j2
@@ -26,6 +26,8 @@ MONGO_EXCLUDE_REGEX="{{ docker_database_backup_mongo_exclude }}"
 
 KEEP_DAYS="{{ docker_database_backup_keep_days }}"
 
+LOG_FAILURE_REGEX="{{ docker_database_backup_failure_keywords }}"
+
 
 # get current directory
 CURRENT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
@@ -124,7 +126,13 @@ done
 
 {% if docker_database_backup_ping | length > 0 %}
 # ping monitoring
+{% if docker_database_backup_failure_keywords | length > 0 %}
+# check output for e.g. collation warnings
+cat "${CURRENT_DIR}/last_run.txt" | grep -E "${LOG_FAILURE_REGEX}" || SUM_OF_EXIT_CODES+=1
+{% endif %}
+# prepare message body
 ping_body="${SUM_OF_BACKUPS} backups started:"$'\n'$(tail --bytes=1000 "${CURRENT_DIR}/last_run.txt")
+# call monitoring
 curl -fsS -m 10 --retry 5 -o /dev/null --data-raw "${ping_body}" \
   "{{ docker_database_backup_ping }}/${SUM_OF_EXIT_CODES}"
 {% endif %}


### PR DESCRIPTION
Our mostly automated postgres updates sometimes need manual intervention.  
That However never reaches our radar since it just silently complains:  

> WARNING: database "postgres" has a collation version mismatch
> DETAIL: The database was created using collation version 2.36, but the operating system provides version 2.41.

To catch such complaints I've added a simple check to the existing monitoring logic in the db dump bash script:  
It reads its own log file and greps for a user defined failure keyword (`collation` in my case).  
If the search is successful `SUM_OF_EXIT_CODES` is incremented as it would be if any of the dump commands had failed.
That way our monitoring (in my case healthchecks.io) gets alerted